### PR TITLE
completing handle_csv_upload, adding tests

### DIFF
--- a/src/handler.py
+++ b/src/handler.py
@@ -32,7 +32,11 @@ def handle_csv_upload(event, context):
         for k, v in user.items():
             k = new_keys[k] if k in new_keys else k.lower()
             if k == 'salary':
-                v = int(v)
+                try:
+                    v = int(v)
+                except ValueError as e:
+                    response_body['errors'].append(str(e))
+                    continue
             elif k == 'hire_date':
                 v = datetime.datetime.strptime(v, '%m/%d/%Y')
             elif k == 'manager_id' and v:

--- a/src/handler.py
+++ b/src/handler.py
@@ -2,6 +2,7 @@ import json
 import os
 import csv
 import datetime
+import re
 from pymongo import MongoClient
 
 
@@ -41,6 +42,10 @@ def handle_csv_upload(event, context):
                 v = datetime.datetime.strptime(v, '%m/%d/%Y')
             elif k == 'manager_id' and v:
                 v = db.user.find_one({'normalized_email': user['Manager']})['_id']
+            elif k == 'normalized_email':
+                if not re.match(r'[\w_\-.%]+@(\w+-?)*\w+\.[a-zA-Z]{2,}$', v):  # check that email addr is valid
+                    response_body['errors'].append(f"{v} is not a valid email address.")
+                v = v.lower()  # normalize
             user_data[k] = v
 
         # check whether user already exists in db

--- a/src/handler.py
+++ b/src/handler.py
@@ -26,6 +26,7 @@ def handle_csv_upload(event, context):
         'Manager': 'manager_id',
         'Hire Date': 'hire_date',
     }
+    event_user_ids = []
 
     for user in event_data:
         # standardize data
@@ -41,53 +42,133 @@ def handle_csv_upload(event, context):
             elif k == 'hire_date':
                 v = datetime.datetime.strptime(v, '%m/%d/%Y')
             elif k == 'manager_id' and v:
-                v = db.user.find_one({'normalized_email': user['Manager']})['_id'] or None
+                manager = db.user.find_one({'normalized_email': user['Manager']})
+                if manager:
+                    v = manager['_id']
+                # otherwise value will remain an email address for now
             elif k == 'normalized_email':
                 if not re.match(r'\s*[\w_\-.%]+@(\w+-?)*\w+\.[a-zA-Z]{2,}\s*$', v):  # check that email addr is valid
                     response_body['errors'].append(f"{v} is not a valid email address.")
                 v = v.lower().strip()  # normalize
             user_data[k] = v
 
+
         # check whether user already exists in db
         existing_user = db.user.find_one({'normalized_email': user_data['normalized_email']})
         # import pdb; pdb.set_trace()
 
-
         if existing_user:
-            # insert chain of command
-            user_record = db.user.find_one({'normalized_email': user_data['normalized_email']})
-            manager_id = user_data['manager_id']
-            user_id = user_record['_id']
-
-            data = {"user_id": user_id,
-                    "chain_of_command": []}
-            # import pdb; pdb.set_trace()
-            if manager_id:
-                data['chain_of_command'].append(manager_id)
-                current_user = db.user.find_one({'_id': manager_id})
-                while current_user['manager_id']:
-                    data['chain_of_command'].append(user_data['manager_id'])
-                    current_user = db.user.find_one({'_id': user_data['manager_id']})
+            # # insert chain of command
+            # user_record = db.user.find_one({'normalized_email': user_data['normalized_email']})
+            # manager_id = user_data['manager_id']
+            # user_id = user_record['_id']
+            #
+            # data = {"user_id": user_id,
+            #         "chain_of_command": []}
+            # # import pdb; pdb.set_trace()
+            # if manager_id:
+            #     data['chain_of_command'].append(manager_id)
+            #     current_user = db.user.find_one({'_id': manager_id})
+            #     while current_user['manager_id']:
+            #         data['chain_of_command'].append(user_data['manager_id'])
+            #         current_user = db.user.find_one({'_id': user_data['manager_id']})
             # update existing user
             db.user.update_one({'normalized_email': user_data['normalized_email']},
                                {"$set": user_data})
             response_body['numUpdated'] += 1
-            db.chain_of_command.update_one({'user_id': user_id},
-                                           {"$set": data})
+            managers = []
+            if user_data['manager_id']:
+                managers.append(user_data['manager_id'])
+
+                db.chain_of_command.update_one({'user_id': existing_user['_id']},
+                                               {"$set": {'chain_of_command': managers}})
+            event_user_ids.append(existing_user['_id'])
+
         else:
             # insert user
             db.user.insert_one(user_data)
             response_body['numCreated'] += 1
 
-            # insert chain of command
-            data = {"user_id": user_data['_id'],
-                    "chain_of_command": []}
-            current_user = db.user.find_one({'_id': user_data['_id']})
-            while current_user['manager_id']:
-                data['chain_of_command'].append(current_user['manager_id'])
-                current_user = db.user.find_one({'_id': current_user['manager_id']})
+            # # insert chain of command
+            # data = {"user_id": user_data['_id'],
+            #         "chain_of_command": []}
+            # current_user = db.user.find_one({'_id': user_data['_id']})
+            # while current_user['manager_id']:
+            #     data['chain_of_command'].append(current_user['manager_id'])
+            #     current_user = db.user.find_one({'_id': current_user['manager_id']})
+            #
+            # db.chain_of_command.insert_one(data)
+            managers = []
+            if user_data['manager_id']:
+                managers.append(user_data['manager_id'])
+            db.chain_of_command.insert_one({"user_id": user_data['_id'],
+                                            "chain_of_command": managers})
+            event_user_ids.append(user_data['_id'])
 
-            db.chain_of_command.insert_one(data)
+
+    # import pdb; pdb.set_trace()
+
+    # iterate users again to convert manager_ids from emails to ObjectIDs
+    # TODO store pattern as variable
+
+    # update manager_id for users with an email address as manager_id
+    extend_chain_users = []
+    for user in db.user.find({'manager_id': {'$regex': r'\s*[\w_\-.%]+@(\w+-?)*\w+\.[a-zA-Z]{2,}\s*$'}}):
+        # insert chain of command
+        manager_id = db.user.find_one({'normalized_email': user['manager_id']})['_id']
+        db.chain_of_command.update_one({'user_id': user['_id']},
+                                       {"$set": {"chain_of_command": [manager_id]}})
+        db.user.update_one({'normalized_email': user['normalized_email']},
+                           {"$set": {'manager_id': manager_id}})
+        extend_chain_users.append(user)
+
+    def update_chain_of_command(user_id):
+        chain_of_command = []
+        if isinstance(user_id, dict):
+            _id = user_id['_id']
+        else:
+            _id = user_id
+        user = db.user.find_one({'_id': _id})
+        current_user = user
+        while current_user['manager_id']:
+            manager_id = current_user['manager_id']
+            chain_of_command.append(manager_id)
+            current_user = db.user.find_one({'_id': manager_id})
+        db.chain_of_command.update_one({'user_id': user['_id']},
+                                       {"$set": {'chain_of_command': chain_of_command}})
+        # also update the user's subordinates' chains of command
+        for subordinate in db.user.find({'manager_id': user['_id']}):
+            update_chain_of_command(subordinate)
+
+
+    for user_id in event_user_ids:
+        update_chain_of_command(user_id)
+
+        #
+        # current_user = user
+        # while current_user['manager_id']:
+        #     manager_id = current_user['manager_id']
+        #     if isinstance(current_user['manager_id'], str):
+        #         manager_id = db.user.find_one({'normalized_email': manager_id})
+        #     data['chain_of_command'].append(manager_id)
+        #     current_user = db.user.find_one({'_id': manager_id})
+        # db.chain_of_command.update_one({'user_id': user['_id']},
+        #                                {"$set": data})
+
+        #
+        # user_record = db.user.find_one({'normalized_email': user_data['normalized_email']})
+        # manager_id = user_data['manager_id']
+        # user_id = user_record['_id']
+        # data = {"user_id": user_id,
+        #         "chain_of_command": []}
+        # if manager_id:
+        #     data['chain_of_command'].append(manager_id)
+        #     current_user = db.user.find_one({'_id': manager_id})
+        #     while current_user['manager_id']:
+        #         data['chain_of_command'].append(user_data['manager_id'])
+        #         current_user = db.user.find_one({'_id': user_data['manager_id']})
+        # db.chain_of_command.update_one({'user_id': user_id},
+        #                                {"$set": data})
 
     response = {
         "statusCode": 200,

--- a/src/handler.py
+++ b/src/handler.py
@@ -1,5 +1,7 @@
 import json
 import os
+import csv
+import datetime
 from pymongo import MongoClient
 
 db_uri = os.environ.get("MONGO_DB_URI", "localhost")
@@ -15,7 +17,49 @@ def handle_csv_upload(event, context):
         "errors": [],
     }
 
-    # YOUR LOGIC HERE
+    # get users from event
+    event_data = csv.DictReader(event.splitlines())
+
+    new_keys = {
+        'Email': 'normalized_email',
+        'Manager': 'manager_id',
+        'Hire Date': 'hire_date',
+    }
+
+    for user in event_data:
+        # standardize data
+        user_data = {}
+        for k, v in user.items():
+            k = new_keys[k] if k in new_keys else k.lower()
+            if k == 'salary':
+                v = int(v)
+            elif k == 'hire_date':
+                v = datetime.datetime.strptime(v, '%m/%d/%Y')
+            user_data[k] = v
+
+
+
+        # user_data = {new_keys[k] if k in new_keys else k.lower(): v for k, v in user.items()}
+
+        # check whether user already exists in db
+        existing_user = db.user.find_one({'normalized_email': user_data['normalized_email']})
+
+        if existing_user:
+            # update existing user
+            db.user.update_one({'normalized_email': user_data['normalized_email']},
+                               {"$set": user_data})
+            response_body['numUpdated'] += 1
+        else:
+            # create new user
+            db.user.insert_one(user_data)
+            response_body['numCreated'] += 1
+
+        # # update field names
+        # translation = {'Email': 'normalized_email'}
+        # update = {"$rename": translation}
+        # db.user.update({'Email': user['Email']}, update)
+
+        import pdb; pdb.set_trace()
 
     response = {
         "statusCode": 200,

--- a/src/handler.py
+++ b/src/handler.py
@@ -4,11 +4,9 @@ import csv
 import datetime
 from pymongo import MongoClient
 
-from pdb import set_trace
 
 db_uri = os.environ.get("MONGO_DB_URI", "localhost")
 db_name = os.environ.get("MONGO_DB_NAME", "new_hire_test")
-
 db = MongoClient(db_uri)[db_name]
 
 
@@ -41,13 +39,8 @@ def handle_csv_upload(event, context):
                 v = db.user.find_one({'normalized_email': user['Manager']})['_id']
             user_data[k] = v
 
-
-
-        # user_data = {new_keys[k] if k in new_keys else k.lower(): v for k, v in user.items()}
-
         # check whether user already exists in db
         existing_user = db.user.find_one({'normalized_email': user_data['normalized_email']})
-
         if existing_user:
             # update existing user
             db.user.update_one({'normalized_email': user_data['normalized_email']},
@@ -66,12 +59,6 @@ def handle_csv_upload(event, context):
                 data['chain_of_command'].append(current_user['manager_id'])
                 current_user = db.user.find_one({'_id': current_user['manager_id']})
             db.chain_of_command.insert_one(data)
-
-        # # update field names
-        # translation = {'Email': 'normalized_email'}
-        # update = {"$rename": translation}
-        # db.user.update({'Email': user['Email']}, update)
-
 
     response = {
         "statusCode": 200,

--- a/src/handler.py
+++ b/src/handler.py
@@ -37,15 +37,15 @@ def handle_csv_upload(event, context):
                     v = int(v)
                 except ValueError as e:
                     response_body['errors'].append(str(e))
-                    continue
+                    v = None
             elif k == 'hire_date':
                 v = datetime.datetime.strptime(v, '%m/%d/%Y')
             elif k == 'manager_id' and v:
-                v = db.user.find_one({'normalized_email': user['Manager']})['_id']
+                v = db.user.find_one({'normalized_email': user['Manager']})['_id'] or None
             elif k == 'normalized_email':
-                if not re.match(r'[\w_\-.%]+@(\w+-?)*\w+\.[a-zA-Z]{2,}$', v):  # check that email addr is valid
+                if not re.match(r'\s*[\w_\-.%]+@(\w+-?)*\w+\.[a-zA-Z]{2,}\s*$', v):  # check that email addr is valid
                     response_body['errors'].append(f"{v} is not a valid email address.")
-                v = v.lower()  # normalize
+                v = v.lower().strip()  # normalize
             user_data[k] = v
 
         # check whether user already exists in db

--- a/src/test_handler.py
+++ b/src/test_handler.py
@@ -239,3 +239,33 @@ John8,jsmith@performyard2.com,,80000,07/16/2018
     assert (db.user.count() == 10)
     assert (db.chain_of_command.count() == 10)
 
+# TODO test details of CoC implementation
+
+@dummy_data_decorator
+def test_duplicate_name():
+    '''
+    This test should still update Brad and create John, but should return
+    a single error because the salary field for Brad isn't a number
+    '''
+
+    body = '''Name,Email,Manager,Salary,Hire Date
+Bradley Jones,bjones@performyard.com,,90000,02/10/2010
+Bradley Jones,bradj@performyard.com,bjones@performyard.com,90001,07/16/2018
+'''
+
+    response = handle_csv_upload(body, {})
+    assert(response["statusCode"] == 200)
+    body = json.loads(response["body"])
+
+    # Check the response counts
+    assert(body["numCreated"] == 1)
+    assert(body["numUpdated"] == 1)
+    assert(len(body["errors"]) == 0)
+
+    # Check that we added the correct number of users
+    assert(db.user.count() == 3)
+    assert(db.chain_of_command.count() == 3)
+
+    # Check that there are two users with the name Bradley Jones
+    assert(db.user.find({'name': 'Bradley Jones'}).count() == 2)
+

--- a/src/test_handler.py
+++ b/src/test_handler.py
@@ -115,58 +115,58 @@ John Smith,jsmith@performyard.com,bjones@performyard.com,80000,07/16/2018
     assert(john["salary"] == 80000)
     assert(john["manager_id"] == brad["_id"])
     assert(john["hire_date"] == datetime.datetime(2018, 7, 16))
-    #
-    # # Check that Brad is in John's chain of command
-    # john_chain_of_command = db.chain_of_command.find_one(
-    #     {"user_id": john["_id"]})
-    # assert(len(john_chain_of_command["chain_of_command"]) == 1)
-    # assert(john_chain_of_command["chain_of_command"][0] == brad["_id"])
 
-#
-# @dummy_data_decorator
-# def test_invalid_number():
-#     '''
-#     This test should still update Brad and create John, but should return
-#     a single error because the salary field for Brad isn't a number
-#     '''
-#
-#     body = '''Name,Email,Manager,Salary,Hire Date
-# Bradley Jones,bjones@performyard.com,,NOT A NUMBER,02/10/2010
-# John Smith,jsmith@performyard.com,bjones@performyard.com,80000,07/16/2018
-# '''
-#
-#     response = handle_csv_upload(body, {})
-#     assert(response["statusCode"] == 200)
-#     body = json.loads(response["body"])
-#
-#     # Check the response counts
-#     assert(body["numCreated"] == 1)
-#     assert(body["numUpdated"] == 1)
-#     assert(len(body["errors"]) == 1)
-#
-#     # Check that we added the correct number of users
-#     assert(db.user.count() == 3)
-#     assert(db.chain_of_command.count() == 3)
-#
-#     # Check that Brad's salary was updated
-#     brad = db.user.find_one({"normalized_email": "bjones@performyard.com"})
-#     assert(brad["salary"] == 90000)
-#     assert(brad["name"] == "Bradley Jones")
-#
-#     # Check that Brad's chain of command is still empty
-#     brad_chain_of_command = db.chain_of_command.find_one(
-#         {"user_id": brad["_id"]})
-#     assert(len(brad_chain_of_command["chain_of_command"]) == 0)
-#
-#     # Check that John's data was inserted correctly
-#     john = db.user.find_one({"normalized_email": "jsmith@performyard.com"})
-#     assert(john["name"] == "John Smith")
-#     assert(john["salary"] == 80000)
-#     assert(john["manager_id"] == brad["_id"])
-#     assert(john["hire_date"] == datetime.datetime(2018, 7, 16))
-#
-#     # Check that Brad is in John's chain of command
-#     john_chain_of_command = db.chain_of_command.find_one(
-#         {"user_id": john["_id"]})
-#     assert(len(john_chain_of_command["chain_of_command"]) == 1)
-#     assert(john_chain_of_command["chain_of_command"][0] == brad["_id"])
+    # Check that Brad is in John's chain of command
+    john_chain_of_command = db.chain_of_command.find_one(
+        {"user_id": john["_id"]})
+    assert(len(john_chain_of_command["chain_of_command"]) == 1)
+    assert(john_chain_of_command["chain_of_command"][0] == brad["_id"])
+
+
+@dummy_data_decorator
+def test_invalid_number():
+    '''
+    This test should still update Brad and create John, but should return
+    a single error because the salary field for Brad isn't a number
+    '''
+
+    body = '''Name,Email,Manager,Salary,Hire Date
+Bradley Jones,bjones@performyard.com,,NOT A NUMBER,02/10/2010
+John Smith,jsmith@performyard.com,bjones@performyard.com,80000,07/16/2018
+'''
+
+    response = handle_csv_upload(body, {})
+    assert(response["statusCode"] == 200)
+    body = json.loads(response["body"])
+
+    # Check the response counts
+    assert(body["numCreated"] == 1)
+    assert(body["numUpdated"] == 1)
+    assert(len(body["errors"]) == 1)
+
+    # Check that we added the correct number of users
+    assert(db.user.count() == 3)
+    assert(db.chain_of_command.count() == 3)
+
+    # Check that Brad's salary was updated
+    brad = db.user.find_one({"normalized_email": "bjones@performyard.com"})
+    assert(brad["salary"] == 90000)
+    assert(brad["name"] == "Bradley Jones")
+
+    # Check that Brad's chain of command is still empty
+    brad_chain_of_command = db.chain_of_command.find_one(
+        {"user_id": brad["_id"]})
+    assert(len(brad_chain_of_command["chain_of_command"]) == 0)
+
+    # Check that John's data was inserted correctly
+    john = db.user.find_one({"normalized_email": "jsmith@performyard.com"})
+    assert(john["name"] == "John Smith")
+    assert(john["salary"] == 80000)
+    assert(john["manager_id"] == brad["_id"])
+    assert(john["hire_date"] == datetime.datetime(2018, 7, 16))
+
+    # Check that Brad is in John's chain of command
+    john_chain_of_command = db.chain_of_command.find_one(
+        {"user_id": john["_id"]})
+    assert(len(john_chain_of_command["chain_of_command"]) == 1)
+    assert(john_chain_of_command["chain_of_command"][0] == brad["_id"])

--- a/src/test_handler.py
+++ b/src/test_handler.py
@@ -96,25 +96,25 @@ John Smith,jsmith@performyard.com,bjones@performyard.com,80000,07/16/2018
     assert(body["numUpdated"] == 1)
     assert(len(body["errors"]) == 0)
 
-    # # Check that we added the correct number of users
-    # assert(db.user.count() == 3)
-    # assert(db.chain_of_command.count() == 3)
-    #
-    # # Check that Brad's salary was updated
-    # brad = db.user.find_one({"normalized_email": "bjones@performyard.com"})
-    # assert(brad["salary"] == 100000)
-    #
-    # # Check that Brad's chain of command is still empty
-    # brad_chain_of_command = db.chain_of_command.find_one(
-    #     {"user_id": brad["_id"]})
-    # assert(len(brad_chain_of_command["chain_of_command"]) == 0)
-    #
-    # # Check that John's data was inserted correctly
-    # john = db.user.find_one({"normalized_email": "jsmith@performyard.com"})
-    # assert(john["name"] == "John Smith")
-    # assert(john["salary"] == 80000)
-    # assert(john["manager_id"] == brad["_id"])
-    # assert(john["hire_date"] == datetime.datetime(2018, 7, 16))
+    # Check that we added the correct number of users
+    assert(db.user.count() == 3)
+    assert(db.chain_of_command.count() == 3)
+
+    # Check that Brad's salary was updated
+    brad = db.user.find_one({"normalized_email": "bjones@performyard.com"})
+    assert(brad["salary"] == 100000)
+
+    # Check that Brad's chain of command is still empty
+    brad_chain_of_command = db.chain_of_command.find_one(
+        {"user_id": brad["_id"]})
+    assert(len(brad_chain_of_command["chain_of_command"]) == 0)
+
+    # Check that John's data was inserted correctly
+    john = db.user.find_one({"normalized_email": "jsmith@performyard.com"})
+    assert(john["name"] == "John Smith")
+    assert(john["salary"] == 80000)
+    assert(john["manager_id"] == brad["_id"])
+    assert(john["hire_date"] == datetime.datetime(2018, 7, 16))
     #
     # # Check that Brad is in John's chain of command
     # john_chain_of_command = db.chain_of_command.find_one(

--- a/src/test_handler.py
+++ b/src/test_handler.py
@@ -170,3 +170,72 @@ John Smith,jsmith@performyard.com,bjones@performyard.com,80000,07/16/2018
         {"user_id": john["_id"]})
     assert(len(john_chain_of_command["chain_of_command"]) == 1)
     assert(john_chain_of_command["chain_of_command"][0] == brad["_id"])
+
+
+
+@dummy_data_decorator
+def test_invalid_email():
+    '''
+    This test should still update Brad and create John, but should return
+    a single error because the salary field for Brad isn't a number
+    '''
+
+    # users with invalid email addresses
+    body = '''Name,Email,Manager,Salary,Hire Date
+John1,jsmith.com,,80000,07/16/2018
+John2,jsmith@performyard,,80000,07/16/2018
+John3,jsmith(1)@performyard.com,,80000,07/16/2018
+John4,jsmith@performyard@py.com,,80000,07/16/2018
+John5,jsmith@perform--yard.com,,80000,07/16/2018
+John6,jsmith@-performyard.com,,80000,07/16/2018
+John7,jsmith@performyard-.com,,80000,07/16/2018
+John8,jsmith@performyard.c,,80000,07/16/2018
+John9,jsmith@performyard.co2,,80000,07/16/2018
+'''
+
+    response = handle_csv_upload(body, {})
+    assert (response["statusCode"] == 200)
+    body = json.loads(response["body"])
+
+    # Check the response counts
+    assert (body["numCreated"] == 9)
+    assert (body["numUpdated"] == 0)
+    assert (len(body["errors"]) == 9)
+
+    # Check that we added the correct number of users
+    assert (db.user.count() == 11)
+    assert (db.chain_of_command.count() == 11)
+
+
+@dummy_data_decorator
+def test_valid_email():
+    '''
+    This test should still update Brad and create John, but should return
+    a single error because the salary field for Brad isn't a number
+    '''
+
+    # users with valid email addresses
+    body = '''Name,Email,Manager,Salary,Hire Date
+John1,jsmith@performyard.com,,80000,07/16/2018
+John2,JSMITH@PY.NET,,80000,07/16/2018
+John3,j_smith@peformyard.web,,80000,07/16/2018
+John4,j.Smith@py.pizza,,80000,07/16/2018
+John5,jsmith123@perf.org,,80000,07/16/2018
+John6,j-smith@performyard.com,,80000,07/16/2018
+John7,jsmith@perform-yard.com,,80000,07/16/2018
+John8,jsmith@performyard2.com,,80000,07/16/2018
+'''
+
+    response = handle_csv_upload(body, {})
+    assert (response["statusCode"] == 200)
+    body = json.loads(response["body"])
+
+    # Check the response counts
+    assert (body["numCreated"] == 8)
+    assert (body["numUpdated"] == 0)
+    assert (len(body["errors"]) == 0)
+
+    # Check that we added the correct number of users
+    assert (db.user.count() == 10)
+    assert (db.chain_of_command.count() == 10)
+

--- a/src/test_handler.py
+++ b/src/test_handler.py
@@ -96,77 +96,77 @@ John Smith,jsmith@performyard.com,bjones@performyard.com,80000,07/16/2018
     assert(body["numUpdated"] == 1)
     assert(len(body["errors"]) == 0)
 
-    # Check that we added the correct number of users
-    assert(db.user.count() == 3)
-    assert(db.chain_of_command.count() == 3)
+    # # Check that we added the correct number of users
+    # assert(db.user.count() == 3)
+    # assert(db.chain_of_command.count() == 3)
+    #
+    # # Check that Brad's salary was updated
+    # brad = db.user.find_one({"normalized_email": "bjones@performyard.com"})
+    # assert(brad["salary"] == 100000)
+    #
+    # # Check that Brad's chain of command is still empty
+    # brad_chain_of_command = db.chain_of_command.find_one(
+    #     {"user_id": brad["_id"]})
+    # assert(len(brad_chain_of_command["chain_of_command"]) == 0)
+    #
+    # # Check that John's data was inserted correctly
+    # john = db.user.find_one({"normalized_email": "jsmith@performyard.com"})
+    # assert(john["name"] == "John Smith")
+    # assert(john["salary"] == 80000)
+    # assert(john["manager_id"] == brad["_id"])
+    # assert(john["hire_date"] == datetime.datetime(2018, 7, 16))
+    #
+    # # Check that Brad is in John's chain of command
+    # john_chain_of_command = db.chain_of_command.find_one(
+    #     {"user_id": john["_id"]})
+    # assert(len(john_chain_of_command["chain_of_command"]) == 1)
+    # assert(john_chain_of_command["chain_of_command"][0] == brad["_id"])
 
-    # Check that Brad's salary was updated
-    brad = db.user.find_one({"normalized_email": "bjones@performyard.com"})
-    assert(brad["salary"] == 100000)
-
-    # Check that Brad's chain of command is still empty
-    brad_chain_of_command = db.chain_of_command.find_one(
-        {"user_id": brad["_id"]})
-    assert(len(brad_chain_of_command["chain_of_command"]) == 0)
-
-    # Check that John's data was inserted correctly
-    john = db.user.find_one({"normalized_email": "jsmith@performyard.com"})
-    assert(john["name"] == "John Smith")
-    assert(john["salary"] == 80000)
-    assert(john["manager_id"] == brad["_id"])
-    assert(john["hire_date"] == datetime.datetime(2018, 7, 16))
-
-    # Check that Brad is in John's chain of command
-    john_chain_of_command = db.chain_of_command.find_one(
-        {"user_id": john["_id"]})
-    assert(len(john_chain_of_command["chain_of_command"]) == 1)
-    assert(john_chain_of_command["chain_of_command"][0] == brad["_id"])
-
-
-@dummy_data_decorator
-def test_invalid_number():
-    '''
-    This test should still update Brad and create John, but should return
-    a single error because the salary field for Brad isn't a number
-    '''
-
-    body = '''Name,Email,Manager,Salary,Hire Date
-Bradley Jones,bjones@performyard.com,,NOT A NUMBER,02/10/2010
-John Smith,jsmith@performyard.com,bjones@performyard.com,80000,07/16/2018
-'''
-
-    response = handle_csv_upload(body, {})
-    assert(response["statusCode"] == 200)
-    body = json.loads(response["body"])
-
-    # Check the response counts
-    assert(body["numCreated"] == 1)
-    assert(body["numUpdated"] == 1)
-    assert(len(body["errors"]) == 1)
-
-    # Check that we added the correct number of users
-    assert(db.user.count() == 3)
-    assert(db.chain_of_command.count() == 3)
-
-    # Check that Brad's salary was updated
-    brad = db.user.find_one({"normalized_email": "bjones@performyard.com"})
-    assert(brad["salary"] == 90000)
-    assert(brad["name"] == "Bradley Jones")
-
-    # Check that Brad's chain of command is still empty
-    brad_chain_of_command = db.chain_of_command.find_one(
-        {"user_id": brad["_id"]})
-    assert(len(brad_chain_of_command["chain_of_command"]) == 0)
-
-    # Check that John's data was inserted correctly
-    john = db.user.find_one({"normalized_email": "jsmith@performyard.com"})
-    assert(john["name"] == "John Smith")
-    assert(john["salary"] == 80000)
-    assert(john["manager_id"] == brad["_id"])
-    assert(john["hire_date"] == datetime.datetime(2018, 7, 16))
-
-    # Check that Brad is in John's chain of command
-    john_chain_of_command = db.chain_of_command.find_one(
-        {"user_id": john["_id"]})
-    assert(len(john_chain_of_command["chain_of_command"]) == 1)
-    assert(john_chain_of_command["chain_of_command"][0] == brad["_id"])
+#
+# @dummy_data_decorator
+# def test_invalid_number():
+#     '''
+#     This test should still update Brad and create John, but should return
+#     a single error because the salary field for Brad isn't a number
+#     '''
+#
+#     body = '''Name,Email,Manager,Salary,Hire Date
+# Bradley Jones,bjones@performyard.com,,NOT A NUMBER,02/10/2010
+# John Smith,jsmith@performyard.com,bjones@performyard.com,80000,07/16/2018
+# '''
+#
+#     response = handle_csv_upload(body, {})
+#     assert(response["statusCode"] == 200)
+#     body = json.loads(response["body"])
+#
+#     # Check the response counts
+#     assert(body["numCreated"] == 1)
+#     assert(body["numUpdated"] == 1)
+#     assert(len(body["errors"]) == 1)
+#
+#     # Check that we added the correct number of users
+#     assert(db.user.count() == 3)
+#     assert(db.chain_of_command.count() == 3)
+#
+#     # Check that Brad's salary was updated
+#     brad = db.user.find_one({"normalized_email": "bjones@performyard.com"})
+#     assert(brad["salary"] == 90000)
+#     assert(brad["name"] == "Bradley Jones")
+#
+#     # Check that Brad's chain of command is still empty
+#     brad_chain_of_command = db.chain_of_command.find_one(
+#         {"user_id": brad["_id"]})
+#     assert(len(brad_chain_of_command["chain_of_command"]) == 0)
+#
+#     # Check that John's data was inserted correctly
+#     john = db.user.find_one({"normalized_email": "jsmith@performyard.com"})
+#     assert(john["name"] == "John Smith")
+#     assert(john["salary"] == 80000)
+#     assert(john["manager_id"] == brad["_id"])
+#     assert(john["hire_date"] == datetime.datetime(2018, 7, 16))
+#
+#     # Check that Brad is in John's chain of command
+#     john_chain_of_command = db.chain_of_command.find_one(
+#         {"user_id": john["_id"]})
+#     assert(len(john_chain_of_command["chain_of_command"]) == 1)
+#     assert(john_chain_of_command["chain_of_command"][0] == brad["_id"])

--- a/src/test_handler.py
+++ b/src/test_handler.py
@@ -66,24 +66,251 @@ def dummy_data_decorator(test_function):
         db.chain_of_command.drop()
     return f
 
+#
+# @dummy_data_decorator
+# def test_setup():
+#     '''
+#     This test should always pass if your environment is set up correctly
+#     '''
+#     assert(True)
+#
+#
+# @dummy_data_decorator
+# def test_simple_csv():
+#     '''
+#     This should successfully update one user and create one user,
+#     also updating their chain of commands appropriately
+#     '''
+#
+#     body = '''Name,Email,Manager,Salary,Hire Date
+# Brad Jones,bjones@performyard.com,,100000,02/10/2010
+# John Smith,jsmith@performyard.com,bjones@performyard.com,80000,07/16/2018
+# '''
+#
+#     response = handle_csv_upload(body, {})
+#     assert(response["statusCode"] == 200)
+#     body = json.loads(response["body"])
+#
+#     # Check the response counts
+#     assert(body["numCreated"] == 1)
+#     assert(body["numUpdated"] == 1)
+#     assert(len(body["errors"]) == 0)
+#
+#     # Check that we added the correct number of users
+#     assert(db.user.count() == 3)
+#     assert(db.chain_of_command.count() == 3)
+#
+#     # Check that Brad's salary was updated
+#     brad = db.user.find_one({"normalized_email": "bjones@performyard.com"})
+#     assert(brad["salary"] == 100000)
+#
+#     # Check that Brad's chain of command is still empty
+#     brad_chain_of_command = db.chain_of_command.find_one(
+#         {"user_id": brad["_id"]})
+#     assert(len(brad_chain_of_command["chain_of_command"]) == 0)
+#
+#     # Check that John's data was inserted correctly
+#     john = db.user.find_one({"normalized_email": "jsmith@performyard.com"})
+#     assert(john["name"] == "John Smith")
+#     assert(john["salary"] == 80000)
+#     assert(john["manager_id"] == brad["_id"])
+#     assert(john["hire_date"] == datetime.datetime(2018, 7, 16))
+#
+#     # Check that Brad is in John's chain of command
+#     john_chain_of_command = db.chain_of_command.find_one(
+#         {"user_id": john["_id"]})
+#     assert(len(john_chain_of_command["chain_of_command"]) == 1)
+#     assert(john_chain_of_command["chain_of_command"][0] == brad["_id"])
+#
+#
+# @dummy_data_decorator
+# def test_invalid_number():
+#     '''
+#     This test should still update Brad and create John, but should return
+#     a single error because the salary field for Brad isn't a number
+#     '''
+#
+#     body = '''Name,Email,Manager,Salary,Hire Date
+# Bradley Jones,bjones@performyard.com,,NOT A NUMBER,02/10/2010
+# John Smith,jsmith@performyard.com,bjones@performyard.com,80000,07/16/2018
+# '''
+#
+#     response = handle_csv_upload(body, {})
+#     assert(response["statusCode"] == 200)
+#     body = json.loads(response["body"])
+#
+#     # Check the response counts
+#     assert(body["numCreated"] == 1)
+#     assert(body["numUpdated"] == 1)
+#     assert(len(body["errors"]) == 1)
+#
+#     # Check that we added the correct number of users
+#     assert(db.user.count() == 3)
+#     assert(db.chain_of_command.count() == 3)
+#
+#     # Check that Brad's salary was updated
+#     brad = db.user.find_one({"normalized_email": "bjones@performyard.com"})
+#     assert(brad["salary"] == 90000)
+#     assert(brad["name"] == "Bradley Jones")
+#
+#     # Check that Brad's chain of command is still empty
+#     brad_chain_of_command = db.chain_of_command.find_one(
+#         {"user_id": brad["_id"]})
+#     assert(len(brad_chain_of_command["chain_of_command"]) == 0)
+#
+#     # Check that John's data was inserted correctly
+#     john = db.user.find_one({"normalized_email": "jsmith@performyard.com"})
+#     assert(john["name"] == "John Smith")
+#     assert(john["salary"] == 80000)
+#     assert(john["manager_id"] == brad["_id"])
+#     assert(john["hire_date"] == datetime.datetime(2018, 7, 16))
+#
+#     # Check that Brad is in John's chain of command
+#     john_chain_of_command = db.chain_of_command.find_one(
+#         {"user_id": john["_id"]})
+#     assert(len(john_chain_of_command["chain_of_command"]) == 1)
+#     assert(john_chain_of_command["chain_of_command"][0] == brad["_id"])
+#
+#
+#
+# @dummy_data_decorator
+# def test_invalid_email():
+#     '''
+#     This test should still update Brad and create John, but should return
+#     a single error because the salary field for Brad isn't a number
+#     '''
+#
+#     # users with invalid email addresses
+#     body = '''Name,Email,Manager,Salary,Hire Date
+# John1,jsmith.com,,80000,07/16/2018
+# John2,jsmith@performyard,,80000,07/16/2018
+# John3,jsmith(1)@performyard.com,,80000,07/16/2018
+# John4,jsmith@performyard@py.com,,80000,07/16/2018
+# John5,jsmith@perform--yard.com,,80000,07/16/2018
+# John6,jsmith@-performyard.com,,80000,07/16/2018
+# John7,jsmith@performyard-.com,,80000,07/16/2018
+# John8,jsmith@performyard.c,,80000,07/16/2018
+# John9,jsmith@performyard.co2,,80000,07/16/2018
+# '''
+#
+#     response = handle_csv_upload(body, {})
+#     assert (response["statusCode"] == 200)
+#     body = json.loads(response["body"])
+#
+#     # Check the response counts
+#     assert (body["numCreated"] == 9)
+#     assert (body["numUpdated"] == 0)
+#     assert (len(body["errors"]) == 9)
+#
+#     # Check that we added the correct number of users
+#     assert (db.user.count() == 11)
+#     assert (db.chain_of_command.count() == 11)
+#
+#
+# @dummy_data_decorator
+# def test_valid_email():
+#     '''
+#     This test should still update Brad and create John, but should return
+#     a single error because the salary field for Brad isn't a number
+#     '''
+#
+#     # users with valid email addresses
+#     body = '''Name,Email,Manager,Salary,Hire Date
+# John1,jsmith@performyard.com,,80000,07/16/2018
+# John2,JSMITH@PY.NET,,80000,07/16/2018
+# John3,j_smith@peformyard.web,,80000,07/16/2018
+# John4,j.Smith@py.pizza,,80000,07/16/2018
+# John5,jsmith123@perf.org,,80000,07/16/2018
+# John6,j-smith@performyard.com,,80000,07/16/2018
+# John7,jsmith@perform-yard.com,,80000,07/16/2018
+# John8,jsmith@performyard2.com,,80000,07/16/2018
+# '''
+#
+#     response = handle_csv_upload(body, {})
+#     assert (response["statusCode"] == 200)
+#     body = json.loads(response["body"])
+#
+#     # Check the response counts
+#     assert (body["numCreated"] == 8)
+#     assert (body["numUpdated"] == 0)
+#     assert (len(body["errors"]) == 0)
+#
+#     # Check that we added the correct number of users
+#     assert (db.user.count() == 10)
+#     assert (db.chain_of_command.count() == 10)
+#
+# # TODO test details of CoC implementation
+#
+# @dummy_data_decorator
+# def test_duplicate_name():
+#     '''
+#     This test should still update Brad and create John, but should return
+#     a single error because the salary field for Brad isn't a number
+#     '''
+#
+#     body = '''Name,Email,Manager,Salary,Hire Date
+# Bradley Jones,bjones@performyard.com,,90000,02/10/2010
+# Bradley Jones,bradj@performyard.com,bjones@performyard.com,90001,07/16/2018
+# '''
+#
+#     response = handle_csv_upload(body, {})
+#     assert(response["statusCode"] == 200)
+#     body = json.loads(response["body"])
+#
+#     # Check the response counts
+#     assert(body["numCreated"] == 1)
+#     assert(body["numUpdated"] == 1)
+#     assert(len(body["errors"]) == 0)
+#
+#     # Check that we added the correct number of users
+#     assert(db.user.count() == 3)
+#     assert(db.chain_of_command.count() == 3)
+#
+#     # Check that there are two users with the name Bradley Jones
+#     assert(db.user.find({'name': 'Bradley Jones'}).count() == 2)
+#
+# # TODO fix documentation on all new funcs
+#
+# @dummy_data_decorator
+# def test_duplicate_email():
+#     '''
+#     This test should still update Brad and create John, but should return
+#     a single error because the salary field for Brad isn't a number
+#     '''
+#
+#     body = '''Name,Email,Manager,Salary,Hire Date
+# Bradley Jones,bjones@performyard.com,,90000,02/10/2010
+# John Smith,bjones@performyard.com,,80000,07/16/2018
+# '''
+#
+#     response = handle_csv_upload(body, {})
+#     assert(response["statusCode"] == 200)
+#     body = json.loads(response["body"])
+#
+#     # Check the response counts
+#     assert(body["numCreated"] == 0)
+#     assert(body["numUpdated"] == 2)
+#     assert(len(body["errors"]) == 0)
+#
+#     # Check that we added the correct number of users
+#     assert(db.user.count() == 2)
+#     assert(db.chain_of_command.count() == 2)
+#
+#     # Check that there's only one user with the duplicated email address
+#     assert(db.user.find({'normalized_email': 'bjones@performyard.com'}).count() == 1)
+
+# TODO what if manager created after their subordinate?
 
 @dummy_data_decorator
-def test_setup():
+def test_chain_of_command():
     '''
-    This test should always pass if your environment is set up correctly
-    '''
-    assert(True)
-
-
-@dummy_data_decorator
-def test_simple_csv():
-    '''
-    This should successfully update one user and create one user,
-    also updating their chain of commands appropriately
+    This test should still update Brad and create John, but should return
+    a single error because the salary field for Brad isn't a number
     '''
 
     body = '''Name,Email,Manager,Salary,Hire Date
-Brad Jones,bjones@performyard.com,,100000,02/10/2010
+Sara Bossman,sbossman@performyard.com,,110000,01/01/2020
+Bradley Jones,bjones@performyard.com,sbossman@performyard.com,90000,02/10/2010
 John Smith,jsmith@performyard.com,bjones@performyard.com,80000,07/16/2018
 '''
 
@@ -92,180 +319,17 @@ John Smith,jsmith@performyard.com,bjones@performyard.com,80000,07/16/2018
     body = json.loads(response["body"])
 
     # Check the response counts
-    assert(body["numCreated"] == 1)
+    assert(body["numCreated"] == 2)
     assert(body["numUpdated"] == 1)
     assert(len(body["errors"]) == 0)
 
     # Check that we added the correct number of users
-    assert(db.user.count() == 3)
-    assert(db.chain_of_command.count() == 3)
-
-    # Check that Brad's salary was updated
-    brad = db.user.find_one({"normalized_email": "bjones@performyard.com"})
-    assert(brad["salary"] == 100000)
-
-    # Check that Brad's chain of command is still empty
-    brad_chain_of_command = db.chain_of_command.find_one(
-        {"user_id": brad["_id"]})
-    assert(len(brad_chain_of_command["chain_of_command"]) == 0)
-
-    # Check that John's data was inserted correctly
-    john = db.user.find_one({"normalized_email": "jsmith@performyard.com"})
-    assert(john["name"] == "John Smith")
-    assert(john["salary"] == 80000)
-    assert(john["manager_id"] == brad["_id"])
-    assert(john["hire_date"] == datetime.datetime(2018, 7, 16))
-
-    # Check that Brad is in John's chain of command
-    john_chain_of_command = db.chain_of_command.find_one(
-        {"user_id": john["_id"]})
-    assert(len(john_chain_of_command["chain_of_command"]) == 1)
-    assert(john_chain_of_command["chain_of_command"][0] == brad["_id"])
-
-
-@dummy_data_decorator
-def test_invalid_number():
-    '''
-    This test should still update Brad and create John, but should return
-    a single error because the salary field for Brad isn't a number
-    '''
-
-    body = '''Name,Email,Manager,Salary,Hire Date
-Bradley Jones,bjones@performyard.com,,NOT A NUMBER,02/10/2010
-John Smith,jsmith@performyard.com,bjones@performyard.com,80000,07/16/2018
-'''
-
-    response = handle_csv_upload(body, {})
-    assert(response["statusCode"] == 200)
-    body = json.loads(response["body"])
-
-    # Check the response counts
-    assert(body["numCreated"] == 1)
-    assert(body["numUpdated"] == 1)
-    assert(len(body["errors"]) == 1)
-
-    # Check that we added the correct number of users
-    assert(db.user.count() == 3)
-    assert(db.chain_of_command.count() == 3)
-
-    # Check that Brad's salary was updated
-    brad = db.user.find_one({"normalized_email": "bjones@performyard.com"})
-    assert(brad["salary"] == 90000)
-    assert(brad["name"] == "Bradley Jones")
-
-    # Check that Brad's chain of command is still empty
-    brad_chain_of_command = db.chain_of_command.find_one(
-        {"user_id": brad["_id"]})
-    assert(len(brad_chain_of_command["chain_of_command"]) == 0)
-
-    # Check that John's data was inserted correctly
-    john = db.user.find_one({"normalized_email": "jsmith@performyard.com"})
-    assert(john["name"] == "John Smith")
-    assert(john["salary"] == 80000)
-    assert(john["manager_id"] == brad["_id"])
-    assert(john["hire_date"] == datetime.datetime(2018, 7, 16))
-
-    # Check that Brad is in John's chain of command
-    john_chain_of_command = db.chain_of_command.find_one(
-        {"user_id": john["_id"]})
-    assert(len(john_chain_of_command["chain_of_command"]) == 1)
-    assert(john_chain_of_command["chain_of_command"][0] == brad["_id"])
-
-
-
-@dummy_data_decorator
-def test_invalid_email():
-    '''
-    This test should still update Brad and create John, but should return
-    a single error because the salary field for Brad isn't a number
-    '''
-
-    # users with invalid email addresses
-    body = '''Name,Email,Manager,Salary,Hire Date
-John1,jsmith.com,,80000,07/16/2018
-John2,jsmith@performyard,,80000,07/16/2018
-John3,jsmith(1)@performyard.com,,80000,07/16/2018
-John4,jsmith@performyard@py.com,,80000,07/16/2018
-John5,jsmith@perform--yard.com,,80000,07/16/2018
-John6,jsmith@-performyard.com,,80000,07/16/2018
-John7,jsmith@performyard-.com,,80000,07/16/2018
-John8,jsmith@performyard.c,,80000,07/16/2018
-John9,jsmith@performyard.co2,,80000,07/16/2018
-'''
-
-    response = handle_csv_upload(body, {})
-    assert (response["statusCode"] == 200)
-    body = json.loads(response["body"])
-
-    # Check the response counts
-    assert (body["numCreated"] == 9)
-    assert (body["numUpdated"] == 0)
-    assert (len(body["errors"]) == 9)
-
-    # Check that we added the correct number of users
-    assert (db.user.count() == 11)
-    assert (db.chain_of_command.count() == 11)
-
-
-@dummy_data_decorator
-def test_valid_email():
-    '''
-    This test should still update Brad and create John, but should return
-    a single error because the salary field for Brad isn't a number
-    '''
-
-    # users with valid email addresses
-    body = '''Name,Email,Manager,Salary,Hire Date
-John1,jsmith@performyard.com,,80000,07/16/2018
-John2,JSMITH@PY.NET,,80000,07/16/2018
-John3,j_smith@peformyard.web,,80000,07/16/2018
-John4,j.Smith@py.pizza,,80000,07/16/2018
-John5,jsmith123@perf.org,,80000,07/16/2018
-John6,j-smith@performyard.com,,80000,07/16/2018
-John7,jsmith@perform-yard.com,,80000,07/16/2018
-John8,jsmith@performyard2.com,,80000,07/16/2018
-'''
-
-    response = handle_csv_upload(body, {})
-    assert (response["statusCode"] == 200)
-    body = json.loads(response["body"])
-
-    # Check the response counts
-    assert (body["numCreated"] == 8)
-    assert (body["numUpdated"] == 0)
-    assert (len(body["errors"]) == 0)
-
-    # Check that we added the correct number of users
-    assert (db.user.count() == 10)
-    assert (db.chain_of_command.count() == 10)
-
-# TODO test details of CoC implementation
-
-@dummy_data_decorator
-def test_duplicate_name():
-    '''
-    This test should still update Brad and create John, but should return
-    a single error because the salary field for Brad isn't a number
-    '''
-
-    body = '''Name,Email,Manager,Salary,Hire Date
-Bradley Jones,bjones@performyard.com,,90000,02/10/2010
-Bradley Jones,bradj@performyard.com,bjones@performyard.com,90001,07/16/2018
-'''
-
-    response = handle_csv_upload(body, {})
-    assert(response["statusCode"] == 200)
-    body = json.loads(response["body"])
-
-    # Check the response counts
-    assert(body["numCreated"] == 1)
-    assert(body["numUpdated"] == 1)
-    assert(len(body["errors"]) == 0)
-
-    # Check that we added the correct number of users
-    assert(db.user.count() == 3)
-    assert(db.chain_of_command.count() == 3)
-
-    # Check that there are two users with the name Bradley Jones
-    assert(db.user.find({'name': 'Bradley Jones'}).count() == 2)
-
+    assert(db.user.count() == 4)
+    assert(db.chain_of_command.count() == 4)
+    # import pdb; pdb.set_trace()
+    # Check that each user has the correct number of users in their chain of command
+    for name, cc_len in (("Sara Bossman", 0), ("Bradley Jones", 1), ("John Smith", 2)):
+        user = db.user.find_one({'name': name})
+        chain = db.chain_of_command.find_one({'user_id': user['_id']})
+        # import pdb; pdb.set_trace()
+        assert(len(chain['chain_of_command']) == cc_len)

--- a/src/test_handler.py
+++ b/src/test_handler.py
@@ -8,11 +8,11 @@ from bson import ObjectId
 
 def dummy_data_decorator(test_function):
     def f():
-        '''
+        """
         Drop any existing data and fill in some dummy test data,
         as well as creating indexes; the data will be dropped after
         the test as well
-        '''
+        """
 
         db.user.drop()
         db.user.create_index([
@@ -55,7 +55,8 @@ def dummy_data_decorator(test_function):
 
         dummy_chain_of_commands = [
             {"user_id": dummy_users[0]["_id"], "chain_of_command":[]},
-            {"user_id": dummy_users[1]["_id"], "chain_of_command":[dummy_users[0]]},
+            # edited this so that only brad's ID shows up in the chain of command
+            {"user_id": dummy_users[1]["_id"], "chain_of_command":[dummy_users[0]["_id"]]},
         ]
 
         for chain_of_command in dummy_chain_of_commands:
@@ -69,23 +70,23 @@ def dummy_data_decorator(test_function):
 
 @dummy_data_decorator
 def test_setup():
-    '''
+    """
     This test should always pass if your environment is set up correctly
-    '''
-    assert(True)
+    """
+    assert True
 
 
 @dummy_data_decorator
 def test_simple_csv():
-    '''
+    """
     This should successfully update one user and create one user,
     also updating their chain of commands appropriately
-    '''
+    """
 
-    body = '''Name,Email,Manager,Salary,Hire Date
+    body = """Name,Email,Manager,Salary,Hire Date
 Brad Jones,bjones@performyard.com,,100000,02/10/2010
 John Smith,jsmith@performyard.com,bjones@performyard.com,80000,07/16/2018
-'''
+"""
 
     response = handle_csv_upload(body, {})
     assert(response["statusCode"] == 200)
@@ -125,15 +126,15 @@ John Smith,jsmith@performyard.com,bjones@performyard.com,80000,07/16/2018
 
 @dummy_data_decorator
 def test_invalid_number():
-    '''
+    """
     This test should still update Brad and create John, but should return
     a single error because the salary field for Brad isn't a number
-    '''
+    """
 
-    body = '''Name,Email,Manager,Salary,Hire Date
+    body = """Name,Email,Manager,Salary,Hire Date
 Bradley Jones,bjones@performyard.com,,NOT A NUMBER,02/10/2010
 John Smith,jsmith@performyard.com,bjones@performyard.com,80000,07/16/2018
-'''
+"""
 
     response = handle_csv_upload(body, {})
     assert(response["statusCode"] == 200)
@@ -172,16 +173,15 @@ John Smith,jsmith@performyard.com,bjones@performyard.com,80000,07/16/2018
     assert(john_chain_of_command["chain_of_command"][0] == brad["_id"])
 
 
-
 @dummy_data_decorator
 def test_invalid_email():
-    '''
-    This test should still update Brad and create John, but should return
-    a single error because the salary field for Brad isn't a number
-    '''
+    """
+    This test adds nine new users with different invalid emails.
+    Each user should still be created, but an error should be logged for each invalid email.
+    """
 
     # users with invalid email addresses
-    body = '''Name,Email,Manager,Salary,Hire Date
+    body = """Name,Email,Manager,Salary,Hire Date
 John1,jsmith.com,,80000,07/16/2018
 John2,jsmith@performyard,,80000,07/16/2018
 John3,jsmith(1)@performyard.com,,80000,07/16/2018
@@ -191,7 +191,7 @@ John6,jsmith@-performyard.com,,80000,07/16/2018
 John7,jsmith@performyard-.com,,80000,07/16/2018
 John8,jsmith@performyard.c,,80000,07/16/2018
 John9,jsmith@performyard.co2,,80000,07/16/2018
-'''
+"""
 
     response = handle_csv_upload(body, {})
     assert (response["statusCode"] == 200)
@@ -209,13 +209,13 @@ John9,jsmith@performyard.co2,,80000,07/16/2018
 
 @dummy_data_decorator
 def test_valid_email():
-    '''
-    This test should still update Brad and create John, but should return
-    a single error because the salary field for Brad isn't a number
-    '''
+    """
+    This test adds eight new users with different valid emails.
+    Verify that different valid email formats get added successfully.
+    """
 
     # users with valid email addresses
-    body = '''Name,Email,Manager,Salary,Hire Date
+    body = """Name,Email,Manager,Salary,Hire Date
 John1,jsmith@performyard.com,,80000,07/16/2018
 John2,JSMITH@PY.NET,,80000,07/16/2018
 John3,j_smith@peformyard.web,,80000,07/16/2018
@@ -224,7 +224,7 @@ John5,jsmith123@perf.org,,80000,07/16/2018
 John6,j-smith@performyard.com,,80000,07/16/2018
 John7,jsmith@perform-yard.com,,80000,07/16/2018
 John8,jsmith@performyard2.com,,80000,07/16/2018
-'''
+"""
 
     response = handle_csv_upload(body, {})
     assert (response["statusCode"] == 200)
@@ -239,19 +239,18 @@ John8,jsmith@performyard2.com,,80000,07/16/2018
     assert (db.user.count() == 10)
     assert (db.chain_of_command.count() == 10)
 
-# TODO test details of CoC implementation
 
 @dummy_data_decorator
 def test_duplicate_name():
-    '''
-    This test should still update Brad and create John, but should return
-    a single error because the salary field for Brad isn't a number
-    '''
+    """
+    This test verifies that different users can be added to the db with the same name,
+    as long as they have different emails.
+    """
 
-    body = '''Name,Email,Manager,Salary,Hire Date
+    body = """Name,Email,Manager,Salary,Hire Date
 Bradley Jones,bjones@performyard.com,,90000,02/10/2010
 Bradley Jones,bradj@performyard.com,bjones@performyard.com,90001,07/16/2018
-'''
+"""
 
     response = handle_csv_upload(body, {})
     assert(response["statusCode"] == 200)
@@ -269,19 +268,18 @@ Bradley Jones,bradj@performyard.com,bjones@performyard.com,90001,07/16/2018
     # Check that there are two users with the name Bradley Jones
     assert(db.user.find({'name': 'Bradley Jones'}).count() == 2)
 
-# TODO fix documentation on all new funcs
 
 @dummy_data_decorator
 def test_duplicate_email():
-    '''
-    This test should still update Brad and create John, but should return
-    a single error because the salary field for Brad isn't a number
-    '''
+    """
+    This test checks behavior when adding multiple records with the same email address.
+    Users with the same email should be considered the same user, so duplicate users should be updated.
+    """
 
-    body = '''Name,Email,Manager,Salary,Hire Date
+    body = """Name,Email,Manager,Salary,Hire Date
 Bradley Jones,bjones@performyard.com,,90000,02/10/2010
 John Smith,bjones@performyard.com,,80000,07/16/2018
-'''
+"""
 
     response = handle_csv_upload(body, {})
     assert(response["statusCode"] == 200)
@@ -299,20 +297,18 @@ John Smith,bjones@performyard.com,,80000,07/16/2018
     # Check that there's only one user with the duplicated email address
     assert(db.user.find({'normalized_email': 'bjones@performyard.com'}).count() == 1)
 
-# TODO what if manager created after their subordinate?
 
 @dummy_data_decorator
 def test_chain_of_command():
-    '''
-    This test should still update Brad and create John, but should return
-    a single error because the salary field for Brad isn't a number
-    '''
+    """
+    This test verifies that longer chains of command get handled correctly.
+    """
 
-    body = '''Name,Email,Manager,Salary,Hire Date
+    body = """Name,Email,Manager,Salary,Hire Date
 Sara Bossman,sbossman@performyard.com,,110000,01/01/2020
 Bradley Jones,bjones@performyard.com,sbossman@performyard.com,90000,02/10/2010
 John Smith,jsmith@performyard.com,bjones@performyard.com,80000,07/16/2018
-'''
+"""
 
     response = handle_csv_upload(body, {})
     assert(response["statusCode"] == 200)
@@ -326,25 +322,25 @@ John Smith,jsmith@performyard.com,bjones@performyard.com,80000,07/16/2018
     # Check that we added the correct number of users
     assert(db.user.count() == 4)
     assert(db.chain_of_command.count() == 4)
-    # import pdb; pdb.set_trace()
+
     # Check that each user has the correct number of users in their chain of command
     for name, cc_len in (("Sara Bossman", 0), ("Bradley Jones", 1), ("John Smith", 2)):
         user = db.user.find_one({'name': name})
         chain = db.chain_of_command.find_one({'user_id': user['_id']})
-        # import pdb; pdb.set_trace()
         assert(len(chain['chain_of_command']) == cc_len)
+
 
 @dummy_data_decorator
 def test_manager_created_after_subordinate():
-    '''
-    This test should still update Brad and create John, but should return
-    a single error because the salary field for Brad isn't a number
-    '''
+    """
+    This test verifies that chain of command is still handled correctly when a manager user
+    is created after a subordinate.
+    """
 
-    body = '''Name,Email,Manager,Salary,Hire Date
+    body = """Name,Email,Manager,Salary,Hire Date
 Bradley Jones,bjones@performyard.com,sbossman@performyard.com,90000,02/10/2010
 Sara Bossman,sbossman@performyard.com,,110000,01/01/2020
-'''
+"""
 
     response = handle_csv_upload(body, {})
     assert(response["statusCode"] == 200)
@@ -363,12 +359,11 @@ Sara Bossman,sbossman@performyard.com,,110000,01/01/2020
     for name, cc_len in (("Sara Bossman", 0), ("Bradley Jones", 1)):
         user = db.user.find_one({'name': name})
         chain = db.chain_of_command.find_one({'user_id': user['_id']})
-        # import pdb; pdb.set_trace()
         assert(len(chain['chain_of_command']) == cc_len)
 
     # Check that Brad's manager_id is Sara's user_id
     manager_id = db.user.find_one({'name': 'Bradley Jones'})['manager_id']
     assert(isinstance(manager_id, ObjectId))
     manager = db.user.find_one({'_id': manager_id})
-    assert(manager)
+    assert manager
     assert(manager['name'] == 'Sara Bossman')

--- a/src/test_handler.py
+++ b/src/test_handler.py
@@ -66,238 +66,238 @@ def dummy_data_decorator(test_function):
         db.chain_of_command.drop()
     return f
 
-#
-# @dummy_data_decorator
-# def test_setup():
-#     '''
-#     This test should always pass if your environment is set up correctly
-#     '''
-#     assert(True)
-#
-#
-# @dummy_data_decorator
-# def test_simple_csv():
-#     '''
-#     This should successfully update one user and create one user,
-#     also updating their chain of commands appropriately
-#     '''
-#
-#     body = '''Name,Email,Manager,Salary,Hire Date
-# Brad Jones,bjones@performyard.com,,100000,02/10/2010
-# John Smith,jsmith@performyard.com,bjones@performyard.com,80000,07/16/2018
-# '''
-#
-#     response = handle_csv_upload(body, {})
-#     assert(response["statusCode"] == 200)
-#     body = json.loads(response["body"])
-#
-#     # Check the response counts
-#     assert(body["numCreated"] == 1)
-#     assert(body["numUpdated"] == 1)
-#     assert(len(body["errors"]) == 0)
-#
-#     # Check that we added the correct number of users
-#     assert(db.user.count() == 3)
-#     assert(db.chain_of_command.count() == 3)
-#
-#     # Check that Brad's salary was updated
-#     brad = db.user.find_one({"normalized_email": "bjones@performyard.com"})
-#     assert(brad["salary"] == 100000)
-#
-#     # Check that Brad's chain of command is still empty
-#     brad_chain_of_command = db.chain_of_command.find_one(
-#         {"user_id": brad["_id"]})
-#     assert(len(brad_chain_of_command["chain_of_command"]) == 0)
-#
-#     # Check that John's data was inserted correctly
-#     john = db.user.find_one({"normalized_email": "jsmith@performyard.com"})
-#     assert(john["name"] == "John Smith")
-#     assert(john["salary"] == 80000)
-#     assert(john["manager_id"] == brad["_id"])
-#     assert(john["hire_date"] == datetime.datetime(2018, 7, 16))
-#
-#     # Check that Brad is in John's chain of command
-#     john_chain_of_command = db.chain_of_command.find_one(
-#         {"user_id": john["_id"]})
-#     assert(len(john_chain_of_command["chain_of_command"]) == 1)
-#     assert(john_chain_of_command["chain_of_command"][0] == brad["_id"])
-#
-#
-# @dummy_data_decorator
-# def test_invalid_number():
-#     '''
-#     This test should still update Brad and create John, but should return
-#     a single error because the salary field for Brad isn't a number
-#     '''
-#
-#     body = '''Name,Email,Manager,Salary,Hire Date
-# Bradley Jones,bjones@performyard.com,,NOT A NUMBER,02/10/2010
-# John Smith,jsmith@performyard.com,bjones@performyard.com,80000,07/16/2018
-# '''
-#
-#     response = handle_csv_upload(body, {})
-#     assert(response["statusCode"] == 200)
-#     body = json.loads(response["body"])
-#
-#     # Check the response counts
-#     assert(body["numCreated"] == 1)
-#     assert(body["numUpdated"] == 1)
-#     assert(len(body["errors"]) == 1)
-#
-#     # Check that we added the correct number of users
-#     assert(db.user.count() == 3)
-#     assert(db.chain_of_command.count() == 3)
-#
-#     # Check that Brad's salary was updated
-#     brad = db.user.find_one({"normalized_email": "bjones@performyard.com"})
-#     assert(brad["salary"] == 90000)
-#     assert(brad["name"] == "Bradley Jones")
-#
-#     # Check that Brad's chain of command is still empty
-#     brad_chain_of_command = db.chain_of_command.find_one(
-#         {"user_id": brad["_id"]})
-#     assert(len(brad_chain_of_command["chain_of_command"]) == 0)
-#
-#     # Check that John's data was inserted correctly
-#     john = db.user.find_one({"normalized_email": "jsmith@performyard.com"})
-#     assert(john["name"] == "John Smith")
-#     assert(john["salary"] == 80000)
-#     assert(john["manager_id"] == brad["_id"])
-#     assert(john["hire_date"] == datetime.datetime(2018, 7, 16))
-#
-#     # Check that Brad is in John's chain of command
-#     john_chain_of_command = db.chain_of_command.find_one(
-#         {"user_id": john["_id"]})
-#     assert(len(john_chain_of_command["chain_of_command"]) == 1)
-#     assert(john_chain_of_command["chain_of_command"][0] == brad["_id"])
-#
-#
-#
-# @dummy_data_decorator
-# def test_invalid_email():
-#     '''
-#     This test should still update Brad and create John, but should return
-#     a single error because the salary field for Brad isn't a number
-#     '''
-#
-#     # users with invalid email addresses
-#     body = '''Name,Email,Manager,Salary,Hire Date
-# John1,jsmith.com,,80000,07/16/2018
-# John2,jsmith@performyard,,80000,07/16/2018
-# John3,jsmith(1)@performyard.com,,80000,07/16/2018
-# John4,jsmith@performyard@py.com,,80000,07/16/2018
-# John5,jsmith@perform--yard.com,,80000,07/16/2018
-# John6,jsmith@-performyard.com,,80000,07/16/2018
-# John7,jsmith@performyard-.com,,80000,07/16/2018
-# John8,jsmith@performyard.c,,80000,07/16/2018
-# John9,jsmith@performyard.co2,,80000,07/16/2018
-# '''
-#
-#     response = handle_csv_upload(body, {})
-#     assert (response["statusCode"] == 200)
-#     body = json.loads(response["body"])
-#
-#     # Check the response counts
-#     assert (body["numCreated"] == 9)
-#     assert (body["numUpdated"] == 0)
-#     assert (len(body["errors"]) == 9)
-#
-#     # Check that we added the correct number of users
-#     assert (db.user.count() == 11)
-#     assert (db.chain_of_command.count() == 11)
-#
-#
-# @dummy_data_decorator
-# def test_valid_email():
-#     '''
-#     This test should still update Brad and create John, but should return
-#     a single error because the salary field for Brad isn't a number
-#     '''
-#
-#     # users with valid email addresses
-#     body = '''Name,Email,Manager,Salary,Hire Date
-# John1,jsmith@performyard.com,,80000,07/16/2018
-# John2,JSMITH@PY.NET,,80000,07/16/2018
-# John3,j_smith@peformyard.web,,80000,07/16/2018
-# John4,j.Smith@py.pizza,,80000,07/16/2018
-# John5,jsmith123@perf.org,,80000,07/16/2018
-# John6,j-smith@performyard.com,,80000,07/16/2018
-# John7,jsmith@perform-yard.com,,80000,07/16/2018
-# John8,jsmith@performyard2.com,,80000,07/16/2018
-# '''
-#
-#     response = handle_csv_upload(body, {})
-#     assert (response["statusCode"] == 200)
-#     body = json.loads(response["body"])
-#
-#     # Check the response counts
-#     assert (body["numCreated"] == 8)
-#     assert (body["numUpdated"] == 0)
-#     assert (len(body["errors"]) == 0)
-#
-#     # Check that we added the correct number of users
-#     assert (db.user.count() == 10)
-#     assert (db.chain_of_command.count() == 10)
-#
-# # TODO test details of CoC implementation
-#
-# @dummy_data_decorator
-# def test_duplicate_name():
-#     '''
-#     This test should still update Brad and create John, but should return
-#     a single error because the salary field for Brad isn't a number
-#     '''
-#
-#     body = '''Name,Email,Manager,Salary,Hire Date
-# Bradley Jones,bjones@performyard.com,,90000,02/10/2010
-# Bradley Jones,bradj@performyard.com,bjones@performyard.com,90001,07/16/2018
-# '''
-#
-#     response = handle_csv_upload(body, {})
-#     assert(response["statusCode"] == 200)
-#     body = json.loads(response["body"])
-#
-#     # Check the response counts
-#     assert(body["numCreated"] == 1)
-#     assert(body["numUpdated"] == 1)
-#     assert(len(body["errors"]) == 0)
-#
-#     # Check that we added the correct number of users
-#     assert(db.user.count() == 3)
-#     assert(db.chain_of_command.count() == 3)
-#
-#     # Check that there are two users with the name Bradley Jones
-#     assert(db.user.find({'name': 'Bradley Jones'}).count() == 2)
-#
-# # TODO fix documentation on all new funcs
-#
-# @dummy_data_decorator
-# def test_duplicate_email():
-#     '''
-#     This test should still update Brad and create John, but should return
-#     a single error because the salary field for Brad isn't a number
-#     '''
-#
-#     body = '''Name,Email,Manager,Salary,Hire Date
-# Bradley Jones,bjones@performyard.com,,90000,02/10/2010
-# John Smith,bjones@performyard.com,,80000,07/16/2018
-# '''
-#
-#     response = handle_csv_upload(body, {})
-#     assert(response["statusCode"] == 200)
-#     body = json.loads(response["body"])
-#
-#     # Check the response counts
-#     assert(body["numCreated"] == 0)
-#     assert(body["numUpdated"] == 2)
-#     assert(len(body["errors"]) == 0)
-#
-#     # Check that we added the correct number of users
-#     assert(db.user.count() == 2)
-#     assert(db.chain_of_command.count() == 2)
-#
-#     # Check that there's only one user with the duplicated email address
-#     assert(db.user.find({'normalized_email': 'bjones@performyard.com'}).count() == 1)
+
+@dummy_data_decorator
+def test_setup():
+    '''
+    This test should always pass if your environment is set up correctly
+    '''
+    assert(True)
+
+
+@dummy_data_decorator
+def test_simple_csv():
+    '''
+    This should successfully update one user and create one user,
+    also updating their chain of commands appropriately
+    '''
+
+    body = '''Name,Email,Manager,Salary,Hire Date
+Brad Jones,bjones@performyard.com,,100000,02/10/2010
+John Smith,jsmith@performyard.com,bjones@performyard.com,80000,07/16/2018
+'''
+
+    response = handle_csv_upload(body, {})
+    assert(response["statusCode"] == 200)
+    body = json.loads(response["body"])
+
+    # Check the response counts
+    assert(body["numCreated"] == 1)
+    assert(body["numUpdated"] == 1)
+    assert(len(body["errors"]) == 0)
+
+    # Check that we added the correct number of users
+    assert(db.user.count() == 3)
+    assert(db.chain_of_command.count() == 3)
+
+    # Check that Brad's salary was updated
+    brad = db.user.find_one({"normalized_email": "bjones@performyard.com"})
+    assert(brad["salary"] == 100000)
+
+    # Check that Brad's chain of command is still empty
+    brad_chain_of_command = db.chain_of_command.find_one(
+        {"user_id": brad["_id"]})
+    assert(len(brad_chain_of_command["chain_of_command"]) == 0)
+
+    # Check that John's data was inserted correctly
+    john = db.user.find_one({"normalized_email": "jsmith@performyard.com"})
+    assert(john["name"] == "John Smith")
+    assert(john["salary"] == 80000)
+    assert(john["manager_id"] == brad["_id"])
+    assert(john["hire_date"] == datetime.datetime(2018, 7, 16))
+
+    # Check that Brad is in John's chain of command
+    john_chain_of_command = db.chain_of_command.find_one(
+        {"user_id": john["_id"]})
+    assert(len(john_chain_of_command["chain_of_command"]) == 1)
+    assert(john_chain_of_command["chain_of_command"][0] == brad["_id"])
+
+
+@dummy_data_decorator
+def test_invalid_number():
+    '''
+    This test should still update Brad and create John, but should return
+    a single error because the salary field for Brad isn't a number
+    '''
+
+    body = '''Name,Email,Manager,Salary,Hire Date
+Bradley Jones,bjones@performyard.com,,NOT A NUMBER,02/10/2010
+John Smith,jsmith@performyard.com,bjones@performyard.com,80000,07/16/2018
+'''
+
+    response = handle_csv_upload(body, {})
+    assert(response["statusCode"] == 200)
+    body = json.loads(response["body"])
+
+    # Check the response counts
+    assert(body["numCreated"] == 1)
+    assert(body["numUpdated"] == 1)
+    assert(len(body["errors"]) == 1)
+
+    # Check that we added the correct number of users
+    assert(db.user.count() == 3)
+    assert(db.chain_of_command.count() == 3)
+
+    # Check that Brad's salary was updated
+    brad = db.user.find_one({"normalized_email": "bjones@performyard.com"})
+    assert(brad["salary"] == 90000)
+    assert(brad["name"] == "Bradley Jones")
+
+    # Check that Brad's chain of command is still empty
+    brad_chain_of_command = db.chain_of_command.find_one(
+        {"user_id": brad["_id"]})
+    assert(len(brad_chain_of_command["chain_of_command"]) == 0)
+
+    # Check that John's data was inserted correctly
+    john = db.user.find_one({"normalized_email": "jsmith@performyard.com"})
+    assert(john["name"] == "John Smith")
+    assert(john["salary"] == 80000)
+    assert(john["manager_id"] == brad["_id"])
+    assert(john["hire_date"] == datetime.datetime(2018, 7, 16))
+
+    # Check that Brad is in John's chain of command
+    john_chain_of_command = db.chain_of_command.find_one(
+        {"user_id": john["_id"]})
+    assert(len(john_chain_of_command["chain_of_command"]) == 1)
+    assert(john_chain_of_command["chain_of_command"][0] == brad["_id"])
+
+
+
+@dummy_data_decorator
+def test_invalid_email():
+    '''
+    This test should still update Brad and create John, but should return
+    a single error because the salary field for Brad isn't a number
+    '''
+
+    # users with invalid email addresses
+    body = '''Name,Email,Manager,Salary,Hire Date
+John1,jsmith.com,,80000,07/16/2018
+John2,jsmith@performyard,,80000,07/16/2018
+John3,jsmith(1)@performyard.com,,80000,07/16/2018
+John4,jsmith@performyard@py.com,,80000,07/16/2018
+John5,jsmith@perform--yard.com,,80000,07/16/2018
+John6,jsmith@-performyard.com,,80000,07/16/2018
+John7,jsmith@performyard-.com,,80000,07/16/2018
+John8,jsmith@performyard.c,,80000,07/16/2018
+John9,jsmith@performyard.co2,,80000,07/16/2018
+'''
+
+    response = handle_csv_upload(body, {})
+    assert (response["statusCode"] == 200)
+    body = json.loads(response["body"])
+
+    # Check the response counts
+    assert (body["numCreated"] == 9)
+    assert (body["numUpdated"] == 0)
+    assert (len(body["errors"]) == 9)
+
+    # Check that we added the correct number of users
+    assert (db.user.count() == 11)
+    assert (db.chain_of_command.count() == 11)
+
+
+@dummy_data_decorator
+def test_valid_email():
+    '''
+    This test should still update Brad and create John, but should return
+    a single error because the salary field for Brad isn't a number
+    '''
+
+    # users with valid email addresses
+    body = '''Name,Email,Manager,Salary,Hire Date
+John1,jsmith@performyard.com,,80000,07/16/2018
+John2,JSMITH@PY.NET,,80000,07/16/2018
+John3,j_smith@peformyard.web,,80000,07/16/2018
+John4,j.Smith@py.pizza,,80000,07/16/2018
+John5,jsmith123@perf.org,,80000,07/16/2018
+John6,j-smith@performyard.com,,80000,07/16/2018
+John7,jsmith@perform-yard.com,,80000,07/16/2018
+John8,jsmith@performyard2.com,,80000,07/16/2018
+'''
+
+    response = handle_csv_upload(body, {})
+    assert (response["statusCode"] == 200)
+    body = json.loads(response["body"])
+
+    # Check the response counts
+    assert (body["numCreated"] == 8)
+    assert (body["numUpdated"] == 0)
+    assert (len(body["errors"]) == 0)
+
+    # Check that we added the correct number of users
+    assert (db.user.count() == 10)
+    assert (db.chain_of_command.count() == 10)
+
+# TODO test details of CoC implementation
+
+@dummy_data_decorator
+def test_duplicate_name():
+    '''
+    This test should still update Brad and create John, but should return
+    a single error because the salary field for Brad isn't a number
+    '''
+
+    body = '''Name,Email,Manager,Salary,Hire Date
+Bradley Jones,bjones@performyard.com,,90000,02/10/2010
+Bradley Jones,bradj@performyard.com,bjones@performyard.com,90001,07/16/2018
+'''
+
+    response = handle_csv_upload(body, {})
+    assert(response["statusCode"] == 200)
+    body = json.loads(response["body"])
+
+    # Check the response counts
+    assert(body["numCreated"] == 1)
+    assert(body["numUpdated"] == 1)
+    assert(len(body["errors"]) == 0)
+
+    # Check that we added the correct number of users
+    assert(db.user.count() == 3)
+    assert(db.chain_of_command.count() == 3)
+
+    # Check that there are two users with the name Bradley Jones
+    assert(db.user.find({'name': 'Bradley Jones'}).count() == 2)
+
+# TODO fix documentation on all new funcs
+
+@dummy_data_decorator
+def test_duplicate_email():
+    '''
+    This test should still update Brad and create John, but should return
+    a single error because the salary field for Brad isn't a number
+    '''
+
+    body = '''Name,Email,Manager,Salary,Hire Date
+Bradley Jones,bjones@performyard.com,,90000,02/10/2010
+John Smith,bjones@performyard.com,,80000,07/16/2018
+'''
+
+    response = handle_csv_upload(body, {})
+    assert(response["statusCode"] == 200)
+    body = json.loads(response["body"])
+
+    # Check the response counts
+    assert(body["numCreated"] == 0)
+    assert(body["numUpdated"] == 2)
+    assert(len(body["errors"]) == 0)
+
+    # Check that we added the correct number of users
+    assert(db.user.count() == 2)
+    assert(db.chain_of_command.count() == 2)
+
+    # Check that there's only one user with the duplicated email address
+    assert(db.user.find({'normalized_email': 'bjones@performyard.com'}).count() == 1)
 
 # TODO what if manager created after their subordinate?
 
@@ -333,3 +333,42 @@ John Smith,jsmith@performyard.com,bjones@performyard.com,80000,07/16/2018
         chain = db.chain_of_command.find_one({'user_id': user['_id']})
         # import pdb; pdb.set_trace()
         assert(len(chain['chain_of_command']) == cc_len)
+
+@dummy_data_decorator
+def test_manager_created_after_subordinate():
+    '''
+    This test should still update Brad and create John, but should return
+    a single error because the salary field for Brad isn't a number
+    '''
+
+    body = '''Name,Email,Manager,Salary,Hire Date
+Bradley Jones,bjones@performyard.com,sbossman@performyard.com,90000,02/10/2010
+Sara Bossman,sbossman@performyard.com,,110000,01/01/2020
+'''
+
+    response = handle_csv_upload(body, {})
+    assert(response["statusCode"] == 200)
+    body = json.loads(response["body"])
+
+    # Check the response counts
+    assert(body["numCreated"] == 1)
+    assert(body["numUpdated"] == 1)
+    assert(len(body["errors"]) == 0)
+
+    # Check that we added the correct number of users
+    assert(db.user.count() == 3)
+    assert(db.chain_of_command.count() == 3)
+
+    # Check that each user has the correct number of users in their chain of command
+    for name, cc_len in (("Sara Bossman", 0), ("Bradley Jones", 1)):
+        user = db.user.find_one({'name': name})
+        chain = db.chain_of_command.find_one({'user_id': user['_id']})
+        # import pdb; pdb.set_trace()
+        assert(len(chain['chain_of_command']) == cc_len)
+
+    # Check that Brad's manager_id is Sara's user_id
+    manager_id = db.user.find_one({'name': 'Bradley Jones'})['manager_id']
+    assert(isinstance(manager_id, ObjectId))
+    manager = db.user.find_one({'_id': manager_id})
+    assert(manager)
+    assert(manager['name'] == 'Sara Bossman')


### PR DESCRIPTION
This update completes the handle_csv_upload function and adds several tests:
- test_invalid_email
- test_valid_email
- test_duplicate_name
- test_duplicate_email
- test_chain_of_command
- test_manager_created_after_subordinate

To extend this further, I would add some flexibility in parsing the csv column headers, possibly using regex.
Another worthwhile extension might be to allow different date formats in the csv. handle_csv_upload currently only expects MM/DD/YYYY.